### PR TITLE
Fix storing and access of key callbacks procs, Fix usage

### DIFF
--- a/lib/catch_cache/flush.rb
+++ b/lib/catch_cache/flush.rb
@@ -9,12 +9,13 @@ module CatchCache
           define_method(:flush_cache!) do
             key_callbacks = ClassMethods.key_callbacks
 
-            key_callbacks.keys.each do |key|
+
+            key_callbacks.keys.select{|key| key.to_s.split("__").last == self.class.name.underscore }.each do |key|
               # Get the uniq id defined in the AR model
               begin
                 uniq_id = instance_exec(&key_callbacks[key])
                 # Build the redis cache key
-                cache_key = "#{key.to_s}_#{uniq_id}"
+                cache_key = "#{key.to_s.split("__").first}_#{uniq_id}"
                 redis = Redis.new
                 # Flush the key by setting it to nil
                 redis.set(cache_key, nil)
@@ -54,7 +55,7 @@ module CatchCache
         def cache_id(*args)
           options = args.last if args.last.is_a?(Hash)
 
-          key_callbacks[args.first] = args.second
+          key_callbacks["#{args.first}__#{self.name.underscore}".to_sym] = args.second
           register_callbacks_for(options) if options.present?
         end
 

--- a/lib/catch_cache/flush.rb
+++ b/lib/catch_cache/flush.rb
@@ -4,7 +4,6 @@ module CatchCache
       def included(klass)
         klass.class_eval do
           extend ClassMethods
-          after_commit :flush_cache!
 
           define_method(:flush_cache!) do
             key_callbacks = ClassMethods.key_callbacks


### PR DESCRIPTION
- There is an issue storing the procedures in the `ClassMethods.key_callbacks` as this is being shared across classes (unknown issue).

- There is an issue where where `:flush_cache` is being defined as an `:after_commit` callback no matter what