### PR TITLE
Use base_class to get base class always in case of STI

### DIFF
--- a/lib/catch_cache/flush.rb
+++ b/lib/catch_cache/flush.rb
@@ -8,7 +8,7 @@ module CatchCache
           define_method(:flush_cache!) do
             key_callbacks = ClassMethods.key_callbacks
 
-            key_callbacks.keys.select{|key| key.to_s.split("__").last == self.class.name.underscore }.each do |key|
+            key_callbacks.keys.select{|key| key.to_s.split("__").last == self.class.base_class.name.underscore }.each do |key|
               # Get the uniq id defined in the AR model
               begin
                 uniq_id = instance_exec(&key_callbacks[key])


### PR DESCRIPTION
# problem 
In case of STI, `self.class` returns child class name but `cache_id` gets registered in base class. 
So the cache doesn't get cleared when say, `TextCustomField` is added whereas `CustomField` is the class having cache.

# solution
Use `self.class.base_class` to get base class always.